### PR TITLE
enable custom key comparison

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,32 +16,38 @@ see test.js for API examples
 ```js
 var diffStream = require('sorted-diff-stream')
 var through = require('through2')
- 
+
 var a = through()
 var b = through()
- 
-var diffs = diffStream(a, b, isEqual)
- 
-// this is the default, you dont have to pass `isEqual` above
+
+var diffs = diffStream(a, b, isEqual, compare)
+
+// this is the default `isEqual`, you dont have to pass one above
 function isEqual (a, b, cb) {
   cb(null, a.value === b.value)
   // you can implement your own equality check here instead
 }
- 
+
+// this is the default `compare`, you dont have to pass one above
+function compare (a, b, cb) {
+  cb(null, a.key > b.key ? 1 : a.key < b.key ? -1 : 0)
+  // you can implement your own comparison here instead
+}
+
 diffs.on('data', function (diff) {
   console.log(diff)
 })
- 
+
 a.write({key: 1, value: 'a'})
 a.write({key: 2, value: 'b'})
 a.write({key: 3, value: 'c'})
 a.write({key: 4, value: 'd'})
- 
+
 b.write({key: 1, value: 'a'})
 b.write({key: 3, value: 'c'})
 b.write({key: 4, value: 'd'})
 b.write({key: 5, value: 'e'})
- 
+
 // console output:
 // [{key: 2, value: 'b'}, null]
 // [null, {key: 5, value: 'e'}]


### PR DESCRIPTION
This enables two particular use cases:
- The keys are not strings, such as when they are binary and should be compared with `Buffer.compare`.
- The compared objects do not follow `{key, value}` format, and keys need to be calculated for comparison.
